### PR TITLE
Fix OpenWindow packet

### DIFF
--- a/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/packets/OpenWindow.java
+++ b/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/packets/OpenWindow.java
@@ -73,7 +73,7 @@ public class OpenWindow extends AbstractPacket {
         if (protocolVersion < MINECRAFT_1_14) {
             this.windowId = buf.readUnsignedByte();
             String legacyId = ProtocolUtil.readString(buf);
-            this.title = ChatElement.ofLegacyText(ProtocolUtil.readString(buf));
+            this.title = ChatElement.ofJson(ProtocolUtil.readString(buf));
             int size = buf.readUnsignedByte();
             this.inventoryType = InventoryType.type(legacyId, size, protocolVersion);
             if (this.inventoryType == null) {
@@ -113,7 +113,7 @@ public class OpenWindow extends AbstractPacket {
         if (protocolVersion < MINECRAFT_1_14) {
             buf.writeByte(this.windowId & 0xFF);
             ProtocolUtil.writeString(buf, this.inventoryType == null ? legacyTypeFallback : Objects.requireNonNull(this.inventoryType.legacyTypeId(protocolVersion)));
-            ProtocolUtil.writeString(buf, this.title.asLegacyText());
+            ProtocolUtil.writeString(buf, this.title.asJson());
             buf.writeByte(this.inventoryType == null ? legacySizeFallback : (this.inventoryType.shouldInventorySizeNotBeZero() ? this.inventoryType.getTypicalSize(protocolVersion) & 0xFF : 0));
         } else {
             ProtocolUtil.writeVarInt(buf, this.windowId);


### PR DESCRIPTION
Window title is parsed by 1.8+ clients as json, not legacy string. So, using any json special character will cause client-side error.

Example error for title `asdada Servers`:
![image](https://github.com/Exceptionflug/protocolize-data/assets/43210079/196549b3-189e-4a84-be84-2ae8d8b5541f)
