### PR TITLE
Fix 1.21 clients being kicked when using items

### DIFF
--- a/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/packets/UseItem.java
+++ b/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/packets/UseItem.java
@@ -51,11 +51,25 @@ public class UseItem extends AbstractPacket {
      */
     private int sequence;
 
+    /**
+     * @since protocol version 767 (1.21)
+     */
+    private float yRot;
+    /**
+     * @since protocol version 767 (1.21)
+     */
+    private float xRot;
+
+
     @Override
     public void read(ByteBuf buf, PacketDirection packetDirection, int protocolVersion) {
         hand = Hand.handByProtocolId(ProtocolUtil.readVarInt(buf));
         if (protocolVersion >= MINECRAFT_1_19) {
             sequence = ProtocolUtil.readVarInt(buf);
+        }
+        if (protocolVersion >= MINECRAFT_1_21) {
+            yRot = buf.readFloat();
+            xRot = buf.readFloat();
         }
     }
 
@@ -64,6 +78,10 @@ public class UseItem extends AbstractPacket {
         ProtocolUtil.writeVarInt(buf, hand.protocolId());
         if (protocolVersion >= MINECRAFT_1_19) {
             ProtocolUtil.writeVarInt(buf, sequence);
+        }
+        if (protocolVersion >= MINECRAFT_1_21) {
+            buf.writeFloat(yRot);
+            buf.writeFloat(xRot);
         }
     }
 


### PR DESCRIPTION
Mojang sneakily added head rotation fields to the Use Item packet in 1.21. This causes 1.21 players to be disconnected when using items due to leftover packet data being detected by the decoder. This pr fixes this issue by adding the missing fields. I have contributed this change to wiki.vg as well. 