### PR TITLE
Implement basic component for enchantments and map id component

### DIFF
--- a/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/DataModule.java
+++ b/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/DataModule.java
@@ -153,6 +153,10 @@ public class DataModule implements ProtocolizeModule {
         registrationProvider.registerItemStructuredComponentType(GameProfileComponentImpl.Type.INSTANCE);
         Protocolize.registerService(MaxStackSizeComponent.Factory.class, MaxStackSizeComponentImpl.Type.INSTANCE);
         registrationProvider.registerItemStructuredComponentType(MaxStackSizeComponentImpl.Type.INSTANCE);
+        Protocolize.registerService(EnchantmentsComponent.Factory.class, EnchantmentsComponentImpl.Type.INSTANCE);
+        registrationProvider.registerItemStructuredComponentType(EnchantmentsComponentImpl.Type.INSTANCE);
+        Protocolize.registerService(MapIdComponent.Factory.class, MapIdComponentImpl.Type.INSTANCE);
+        registrationProvider.registerItemStructuredComponentType(MapIdComponentImpl.Type.INSTANCE);
 
         PacketListenerProvider listenerProvider = Protocolize.listenerProvider();
         listenerProvider.registerListener(new CloseWindowListener(Direction.UPSTREAM));

--- a/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/item/component/EnchantmentsComponentImpl.java
+++ b/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/item/component/EnchantmentsComponentImpl.java
@@ -1,0 +1,104 @@
+package dev.simplix.protocolize.data.item.component;
+
+import dev.simplix.protocolize.api.item.component.EnchantmentsComponent;
+import dev.simplix.protocolize.api.item.component.StructuredComponentType;
+import dev.simplix.protocolize.api.mapping.AbstractProtocolMapping;
+import dev.simplix.protocolize.api.mapping.ProtocolIdMapping;
+import dev.simplix.protocolize.api.util.ProtocolUtil;
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static dev.simplix.protocolize.api.util.ProtocolVersions.MINECRAFT_1_20_5;
+import static dev.simplix.protocolize.api.util.ProtocolVersions.MINECRAFT_LATEST;
+
+@Data
+@AllArgsConstructor
+public class EnchantmentsComponentImpl implements EnchantmentsComponent {
+
+    private Map<Integer, Integer> enchantments;
+    private boolean showInTooltip;
+
+    @Override
+    public void read(ByteBuf byteBuf, int protocolVersion) throws Exception {
+        int count = ProtocolUtil.readVarInt(byteBuf);
+        enchantments = new HashMap<>(count);
+        for (int i = 0; i < count; i++) {
+            int id = ProtocolUtil.readVarInt(byteBuf);
+            int level = ProtocolUtil.readVarInt(byteBuf);
+            enchantments.put(id, level);
+        }
+        showInTooltip = byteBuf.readBoolean();
+    }
+
+    @Override
+    public void write(ByteBuf byteBuf, int protocolVersion) throws Exception {
+        ProtocolUtil.writeVarInt(byteBuf, enchantments.size());
+        for (Map.Entry<Integer, Integer> entry : enchantments.entrySet()) {
+            ProtocolUtil.writeVarInt(byteBuf, entry.getKey());
+            ProtocolUtil.writeVarInt(byteBuf, entry.getValue());
+        }
+        byteBuf.writeBoolean(showInTooltip);
+    }
+
+    @Override
+    public StructuredComponentType<?> getType() {
+        return Type.INSTANCE;
+    }
+
+    @Override
+    public void removeEnchantment(int id) {
+        enchantments.remove(id);
+    }
+
+    @Override
+    public void addEnchantment(int id, int level) {
+        enchantments.put(id, level);
+    }
+
+    @Override
+    public void removeAllEnchantments() {
+        enchantments.clear();
+    }
+
+    public static class Type implements StructuredComponentType<EnchantmentsComponent>, Factory {
+
+        public static Type INSTANCE = new Type();
+
+        private static final List<ProtocolIdMapping> MAPPINGS = Arrays.asList(
+            AbstractProtocolMapping.rangedIdMapping(MINECRAFT_1_20_5, MINECRAFT_LATEST, 9)
+        );
+
+        @Override
+        public EnchantmentsComponent create(Map<Integer, Integer> enchantments) {
+            return new EnchantmentsComponentImpl(enchantments, true);
+        }
+
+        @Override
+        public EnchantmentsComponent create(Map<Integer, Integer> enchantments, boolean showInTooltip) {
+            return new EnchantmentsComponentImpl(enchantments, showInTooltip);
+        }
+
+        @Override
+        public String getName() {
+            return "minecraft:enchantments";
+        }
+
+        @Override
+        public List<ProtocolIdMapping> getMappings() {
+            return MAPPINGS;
+        }
+
+        @Override
+        public EnchantmentsComponent createEmpty() {
+            return new EnchantmentsComponentImpl(new HashMap<>(0), true);
+        }
+
+    }
+
+}

--- a/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/item/component/MapIdComponentImpl.java
+++ b/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/item/component/MapIdComponentImpl.java
@@ -1,0 +1,69 @@
+package dev.simplix.protocolize.data.item.component;
+
+import dev.simplix.protocolize.api.item.component.MapIdComponent;
+import dev.simplix.protocolize.api.item.component.StructuredComponentType;
+import dev.simplix.protocolize.api.mapping.AbstractProtocolMapping;
+import dev.simplix.protocolize.api.mapping.ProtocolIdMapping;
+import dev.simplix.protocolize.api.util.ProtocolUtil;
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static dev.simplix.protocolize.api.util.ProtocolVersions.MINECRAFT_1_20_5;
+import static dev.simplix.protocolize.api.util.ProtocolVersions.MINECRAFT_LATEST;
+
+@Data
+@AllArgsConstructor
+public class MapIdComponentImpl implements MapIdComponent {
+
+    private int id;
+
+    @Override
+    public void read(ByteBuf byteBuf, int protocolVersion) throws Exception {
+        id = ProtocolUtil.readVarInt(byteBuf);
+    }
+
+    @Override
+    public void write(ByteBuf byteBuf, int protocolVersion) throws Exception {
+        ProtocolUtil.writeVarInt(byteBuf, id);
+    }
+
+    @Override
+    public StructuredComponentType<?> getType() {
+        return Type.INSTANCE;
+    }
+
+    public static class Type implements StructuredComponentType<MapIdComponent>, Factory {
+
+        public static Type INSTANCE = new Type();
+
+        private static final List<ProtocolIdMapping> MAPPINGS = Arrays.asList(
+            AbstractProtocolMapping.rangedIdMapping(MINECRAFT_1_20_5, MINECRAFT_LATEST, 26)
+        );
+
+        @Override
+        public MapIdComponent create(int id) {
+            return new MapIdComponentImpl(id);
+        }
+
+        @Override
+        public String getName() {
+            return "minecraft:map_id";
+        }
+
+        @Override
+        public List<ProtocolIdMapping> getMappings() {
+            return MAPPINGS;
+        }
+
+        @Override
+        public MapIdComponent createEmpty() {
+            return new MapIdComponentImpl(0);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This must be merged AFTER the protocolize [PR](https://github.com/Exceptionflug/protocolize/pull/246). This is to fix 2 errors happening with item containers.

Enchantments:
```
[09:30:37 ERROR] [Protocolize]: Unable to read item stack from buffer in protocol version 767
java.lang.IllegalStateException: Could not find component type 9 for protocol version 767. This item is not compatible with Protocolize.
        at dev.simplix.protocolize.api.item.StructuredItemStackSerializer.findComponentType(StructuredItemStackSerializer.java:148) ~[?:?]
        at dev.simplix.protocolize.api.item.StructuredItemStackSerializer.readComponentType(StructuredItemStackSerializer.java:136) ~[?:?]
        at dev.simplix.protocolize.api.item.StructuredItemStackSerializer.readComponent(StructuredItemStackSerializer.java:124) ~[?:?]
        at dev.simplix.protocolize.api.item.StructuredItemStackSerializer.read(StructuredItemStackSerializer.java:41) ~[?:?]
        at dev.simplix.protocolize.api.item.ItemStackSerializer.read(ItemStackSerializer.java:48) ~[?:?]
        at dev.simplix.protocolize.data.packets.ClickWindow.read(ClickWindow.java:89) ~[?:?]
        at dev.simplix.protocolize.velocity.packet.VelocityProtocolizePacket.decode(VelocityProtocolizePacket.java:56) ~[?:?]
        at com.velocitypowered.proxy.protocol.netty.MinecraftDecoder.tryDecode(MinecraftDecoder.java:84) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at com.velocitypowered.proxy.protocol.netty.MinecraftDecoder.channelRead(MinecraftDecoder.java:61) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:509) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:407) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[velocity-3.3.0-SNAPSHOT-398.jar:3.3.0-SNAPSHOT (git-350ea7f3-b398)]
        at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
```

Maps:
```
[09:35:19 ERROR] [Protocolize]: Unable to read item stack from buffer in protocol version 767
java.lang.IllegalStateException: Could not find component type 26 for protocol version 767. This item is not compatible with Protocolize.
        at dev.simplix.protocolize.api.item.StructuredItemStackSerializer.findComponentType(StructuredItemStackSerializer.java:148) ~[?:?]
        at dev.simplix.protocolize.api.item.StructuredItemStackSerializer.readComponentType(StructuredItemStackSerializer.java:136) ~[?:?]
        at dev.simplix.protocolize.api.item.StructuredItemStackSerializer.readComponent(StructuredItemStackSerializer.java:124) ~[?:?]
        at dev.simplix.protocolize.api.item.StructuredItemStackSerializer.read(StructuredItemStackSerializer.java:41) ~[?:?]
        at dev.simplix.protocolize.api.item.ItemStackSerializer.read(ItemStackSerializer.java:48) ~[?:?]
        at dev.simplix.protocolize.data.packets.ClickWindow.read(ClickWindow.java:86) ~[?:?]
        at dev.simplix.protocolize.velocity.packet.VelocityProtocolizePacket.decode(VelocityProtocolizePacket.java:56) ~[?:?]
        at com.velocitypowered.proxy.protocol.netty.MinecraftDecoder.tryDecode(MinecraftDecoder.java:83) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at com.velocitypowered.proxy.protocol.netty.MinecraftDecoder.channelRead(MinecraftDecoder.java:60) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:509) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:407) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[velocity-3.3.0-SNAPSHOT-400.jar:3.3.0-SNAPSHOT (git-9d25d309-b400)]
        at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
```